### PR TITLE
Fix vector_set emplace node cleanup

### DIFF
--- a/Awl/VectorSet.h
+++ b/Awl/VectorSet.h
@@ -84,6 +84,21 @@ namespace awl
             m_nodeAlloc.deallocate(node, 1);
         }
 
+        struct NodeDeleter
+        {
+            vector_set * owner;
+
+            void operator()(Node * node) const noexcept
+            {
+                if (node != nullptr)
+                {
+                    owner->DestroyNode(node);
+                }
+            }
+        };
+
+        using NodeHolder = std::unique_ptr<Node, NodeDeleter>;
+
         using List = quick_list<Node>;
 
     public:
@@ -237,8 +252,7 @@ namespace awl
         std::pair<iterator, bool> emplace(Args&&... args)
         {
             Node * parent;
-            //TODO: It is probably a bug. We probably need a deleter here.
-            std::unique_ptr<Node> val_node(CreateNode(std::forward<Args>(args) ...));
+            NodeHolder val_node(CreateNode(std::forward<Args>(args) ...), NodeDeleter{this});
             Node * node = m_tree.FindNodeByKey(val_node->m_val, &parent);
             const bool exists = node != nullptr;
 


### PR DESCRIPTION
## Summary
- ensure `vector_set::emplace` uses allocator-aware cleanup for temporary nodes
- add a custom deleter that returns nodes to the container allocator when insertion fails

## Testing
- ./AwlTest

------
https://chatgpt.com/codex/tasks/task_e_6902833b0108832ebc7e81617c45f3bf