### PR TITLE
Fix string deserialization buffer overflow

### DIFF
--- a/Awl/Io/Rw/StringReadWrite.h
+++ b/Awl/Io/Rw/StringReadWrite.h
@@ -53,8 +53,6 @@ namespace awl::io
 
         //There is non-const version of data() since C++ 17.
         ReadRaw(s, reinterpret_cast<uint8_t *>(val.data()), string_length);
-
-        *(val.data() + len) = 0;
     }
 
     template<


### PR DESCRIPTION
## Summary
- stop writing past the end of the buffer when deserializing std::basic_string values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69028aca447c832eb4bb5af4cd622f70