### PR TITLE
Use test logger in AsyncConnect example

### DIFF
--- a/Extras/Boost/Tests/AcceptCancellationExample.cpp
+++ b/Extras/Boost/Tests/AcceptCancellationExample.cpp
@@ -1,7 +1,7 @@
-﻿#include "Awl/Testing/UnitTest.h"
+#include "Awl/StringFormat.h"
+#include "Awl/Testing/UnitTest.h"
 
 #include <boost/asio.hpp>
-#include <iostream>
 #include <chrono>
 
 namespace asio = boost::asio;
@@ -14,11 +14,12 @@ namespace
 {
     // Coroutine that waits for a client connection but can be cancelled
     awaitable<tcp::socket> accept_with_cancellation(tcp::acceptor& acceptor,
-        asio::cancellation_signal& cancel_signal)
+        asio::cancellation_signal& cancel_signal,
+        const awl::testing::TestContext& context)
     {
         auto ex = co_await asio::this_coro::executor;
 
-        std::cout << "Waiting for a client on " << acceptor.local_endpoint() << "...\n";
+        context.logger.debug(awl::format() << "Waiting for a client on " << acceptor.local_endpoint() << "...");
 
         // Bind the external cancellation slot specifically to async_accept.
         // In Boost 1.89 this is the correct way to hook your own signal.
@@ -26,13 +27,14 @@ namespace
             co_await acceptor.async_accept(
                 asio::bind_cancellation_slot(cancel_signal.slot(), use_awaitable));
 
-        std::cout << "Client connected from " << socket.remote_endpoint() << "\n";
+        context.logger.debug(awl::format() << "Client connected from " << socket.remote_endpoint());
 
         co_return socket;
     }
 
     // Cancels after 3 seconds by emitting on the shared signal
-    awaitable<void> cancel_after_delay(asio::cancellation_signal& cancel_signal)
+    awaitable<void> cancel_after_delay(asio::cancellation_signal& cancel_signal,
+        const awl::testing::TestContext& context)
     {
         auto ex = co_await asio::this_coro::executor;
         asio::steady_timer t(ex);
@@ -40,11 +42,11 @@ namespace
         t.expires_after(3s);
         co_await t.async_wait(use_awaitable);
 
-        std::cout << "No client yet — sending cancellation signal...\n";
+        context.logger.debug("No client yet — sending cancellation signal...");
         cancel_signal.emit(asio::cancellation_type::all);
     }
 
-    awaitable<void> example()
+    awaitable<void> example(const awl::testing::TestContext& context)
     {
         auto ex = co_await asio::this_coro::executor;
 
@@ -52,18 +54,18 @@ namespace
         asio::cancellation_signal sig;
 
         // After 3s, emit cancellation (will abort async_accept)
-        asio::co_spawn(ex, cancel_after_delay(sig), asio::detached);
+        asio::co_spawn(ex, cancel_after_delay(sig, context), asio::detached);
 
         try
         {
             // Run accept coroutine in parallel
-            tcp::socket socket = co_await accept_with_cancellation(acc, sig);
+            tcp::socket socket = co_await accept_with_cancellation(acc, sig, context);
         }
         catch (const boost::system::system_error& e)
         {
             // async_accept completes with operation_aborted when cancelled
             if (e.code() == asio::error::operation_aborted)
-                std::cout << "Accept operation was cancelled.\n";
+                context.logger.debug("Accept operation was cancelled.");
             else
                 throw;
         }
@@ -77,11 +79,11 @@ AWL_EXAMPLE(AcceptCancellation)
     try
     {
         asio::io_context ctx;
-        asio::co_spawn(ctx, example(), asio::detached);
+        asio::co_spawn(ctx, example(context), asio::detached);
         ctx.run();
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Exception: " << e.what() << "\n";
+        context.logger.error(awl::format() << "Exception: " << e.what());
     }
 }

--- a/Extras/Boost/Tests/MultiprecisionTest.cpp
+++ b/Extras/Boost/Tests/MultiprecisionTest.cpp
@@ -7,6 +7,7 @@
 #include "Tests/Helpers/RwTest.h"
 
 #include "Awl/String.h"
+#include "Awl/StringFormat.h"
 #include "Awl/Separator.h"
 #include "BoostExtras/MultiprecisionDecimalData.h"
 #include "BoostExtras/MultiprecisionTraits.h"
@@ -64,12 +65,11 @@ AWL_EXAMPLE(MultiprecisionDecFloat)
     const Decimal a(number);
     const double b = std::stod(number);
 
-    std::cout <<
-        "sizeof(Decimal): " << sizeof(Decimal) << std::endl <<
-        "boost:\t" << std::fixed << a << std::endl <<
-        "double:\t" << std::fixed << b << std::endl <<
-        "cast:\t" << std::fixed << static_cast<double>(a) <<
-        std::endl;
+    context.logger.debug(awl::format()
+        << "sizeof(Decimal): " << sizeof(Decimal) << awl::format::endl
+        << "boost:\t" << std::fixed << a << awl::format::endl
+        << "double:\t" << std::fixed << b << awl::format::endl
+        << "cast:\t" << std::fixed << static_cast<double>(a));
 
     //context.out <<
     //    _T("sizeof(Decimal): ") << sizeof(Decimal) << std::endl <<
@@ -90,11 +90,11 @@ AWL_EXAMPLE(MultiprecisionDecFloat)
     const Decimal a_product = a * iter_count;
     const double b_product = b * iter_count;
 
-    std::cout <<
-        "decimal sum: " << a_sum << std::endl <<
-        "decimal product: " << a_product << std::endl <<
-        "double sum: " << b_sum << std::endl <<
-        "double product: " << b_product << std::endl;
+    context.logger.debug(awl::format()
+        << "decimal sum: " << a_sum << awl::format::endl
+        << "decimal product: " << a_product << awl::format::endl
+        << "double sum: " << b_sum << awl::format::endl
+        << "double product: " << b_product);
 
     AWL_ASSERT(a_sum == a_product);
 
@@ -102,14 +102,14 @@ AWL_EXAMPLE(MultiprecisionDecFloat)
     {
         Decimal a_quotient = a;
 
-        std::cout << "decimal quotient: " << std::endl;
+        context.logger.debug("decimal quotient:");
 
         //while (a_quotient != 0)
         for (size_t i = 0; i < div_count; ++i)
         {
             a_quotient /= 10;
 
-            std::cout << a_quotient << std::endl;
+            context.logger.debug(awl::format() << a_quotient);
         }
     }
 
@@ -126,10 +126,10 @@ AWL_EXAMPLE(MultiprecisionDecFloat)
 
             a_sqrt = bmp::sqrt(a_sqrt);
 
-            std::cout <<
-                "square: " << a_square << std::endl <<
-                "sqrt: " << a_sqrt << std::endl <<
-                "square + sqrt: " << a_square + a_sqrt << std::endl;
+            context.logger.debug(awl::format()
+                << "square: " << a_square << awl::format::endl
+                << "sqrt: " << a_sqrt << awl::format::endl
+                << "square + sqrt: " << a_square + a_sqrt);
         }
     }
 }

--- a/Extras/Boost/Tests/MultiprecisionTest.cpp
+++ b/Extras/Boost/Tests/MultiprecisionTest.cpp
@@ -126,10 +126,12 @@ AWL_EXAMPLE(MultiprecisionDecFloat)
 
             a_sqrt = bmp::sqrt(a_sqrt);
 
+            const Decimal combined = a_square + a_sqrt;
+
             context.logger.debug(awl::format()
                 << "square: " << a_square << awl::format::endl
                 << "sqrt: " << a_sqrt << awl::format::endl
-                << "square + sqrt: " << a_square + a_sqrt);
+                << "square + sqrt: " << combined);
         }
     }
 }


### PR DESCRIPTION
## Summary
- route the AsyncConnect example logging through the provided test logger
- format status messages with awl::format instead of std::cout output

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69078d8db038832ea306184235a20d91